### PR TITLE
各ユーザーの日記一覧画面にアクセスする

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,7 +1,9 @@
 class DiariesController < ApplicationController
-  # diaries_path。現在ログインしているユーザーの日記一覧ページ。
+  # user_diaries_path。ユーザーのidをパラメータで受け取って、@userに入れる。
+  # @userの日記一覧を@diariesに入れる。
   def index
-    @diaries = current_user.diaries
+    @user = User.find(params[:user_id])
+    @diaries = @user.diaries
   end
 
   # new_diary_path

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,11 +1,11 @@
-<h1><%= current_user.nickname %>'s diary</h1>
+<h1><%= @user.nickname %>'s diary</h1>
 
 <%= month_calendar events: @diaries do |date, diaries| %>
   <%= date.day %>
 
   <% diaries.each do |diary| %>
     <div>
-      <%= link_to diary.feeling, diary %>
+      <%= link_to diary.feeling, "#" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/relationships/_follow_button.html.erb
+++ b/app/views/relationships/_follow_button.html.erb
@@ -1,1 +1,1 @@
-<%= button_to t('defaults.follow'), relationships_path(follower: user), method: :post %>
+<%= button_to t('defaults.follow'), relationships_path(follower: user), class: "btn btn-sm btn-outline-primary", method: :post %>

--- a/app/views/relationships/_unfollow_button.html.erb
+++ b/app/views/relationships/_unfollow_button.html.erb
@@ -1,1 +1,1 @@
-<%= button_to t('defaults.unfollow'), relationship_path(current_user.relationships.find_by(follower: user)), method: :delete %>
+<%= button_to t('defaults.unfollow'), relationship_path(current_user.relationships.find_by(follower: user)), class: "btn btn-sm btn-outline-danger", method: :delete %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,7 +10,7 @@
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='navbar-nav ml-auto main-nav align-items-center'>
         <li class='nav-item'>
-          <%= link_to t('defaults.mine'), diaries_path, class: 'nav-link' %>
+          <%= link_to t('defaults.mine'), user_diaries_path(current_user), class: 'nav-link' %>
         </li>
         <li class='nav-item'>
           <a class='nav-link' href='#'>follower's diary</a>
@@ -22,7 +22,7 @@
           <%= link_to t('defaults.logout'), logout_path, method: :delete, class: 'nav-link' %>
         </li>
         <li class='nav-item'>
-          <%= link_to t('defaults.new'), new_diary_path, class: 'nav-link' %>
+          <%= link_to t('defaults.new'), "#", class: 'nav-link' %>
         </li>
         <li class='nav-item'>
           <a class='nav-link' href='#'>💐</a>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,21 +2,21 @@
 
 <h1>Users</h1>
 
-<table>
-  <thead>
+<table class="table table-sm col-12">
+  <thead class="thead-light">
     <tr>
-      <th>nickname</th>
-      <th>name</th>
-      <th colspan="3"></th>
+      <th class="text-center">nickname</th>
+      <th class="text-center">name</th>
+      <th colspan="5"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @users.each do |user| %>
       <tr>
-        <td><%= user.nickname %></td>
-        <td><%= user.name %></td>
-        <td><% if logged_in? && current_user != user %>
+        <td class="text-center"><%= link_to user.nickname, user_diaries_path(user) %></td>
+        <td class="text-center"><%= user.name %></td>
+        <td class="text-center"><% if logged_in? && current_user != user %>
           <% if current_user.following?(user) %>
             <%= render 'relationships/unfollow_button', user: user %>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,9 +3,10 @@ Rails.application.routes.draw do
   root to: 'tops#home'
 
   # new_user_path, users_path
-  resources :users, only: [:new, :create, :index]
-
-  resources :diaries
+  # user_diaries_path(index), new_user_diary_path, edit_user_diary, user_diary(show)
+  resources :users, only: [:new, :create, :index] do
+    resources :diaries
+  end
 
   resources :relationships, only: [:create, :destroy]
 


### PR DESCRIPTION
## 概要

diariesコントローラをusersコントローラにネストしました。
そのためヘッダーのリンクの遷移先が変更になりました。
ユーザー一覧画面のユーザー名を押すと、各ユーザーの日記一覧に遷移するようになりました。

## 影響範囲

日記の詳細ページのリンクを非表示にしたので、詳細ページには現在遷移しません。


## コメント

ネストすることでuser_idを含めて日記の情報を手に入れることができました。