### PR TITLE
日記一覧ページと友達検索ページのレイアウト変更

### DIFF
--- a/app/javascript/src/application.scss
+++ b/app/javascript/src/application.scss
@@ -1,5 +1,6 @@
 @import 'home';
 @import 'simple_calendar';
 @import 'diaries.scss';
+@import 'users.scss';
 @import '~bootstrap/scss/bootstrap';
 @import '~@fortawesome/fontawesome-free/scss/fontawesome';

--- a/app/javascript/src/diaries.scss
+++ b/app/javascript/src/diaries.scss
@@ -37,8 +37,8 @@ input[type="radio"]:checked + label img {
 
 /* 日記詳細の枠 */
 .card {
-  margin: 100px;
-  padding: 100px;
+  margin: 50px;
+  padding: 80px;
 }
 
 
@@ -88,4 +88,27 @@ input[type="radio"]:checked + label img {
 
 .count:hover {
   color: #e54747;
+}
+
+.calendar {
+  margin: 50px;
+  padding: 80px;
+}
+
+.calendar-name {
+  letter-spacing: 0.20em;
+  color: #c76e54;
+}
+
+.feeling {
+  text-align: center;
+  font-size: 20px;
+}
+
+h3.calendar-name {
+  margin-top: 50px;
+}
+
+a:link, a:visited, a:hover, a:active {
+  color: #c76e54;
 }

--- a/app/javascript/src/simple_calendar.scss
+++ b/app/javascript/src/simple_calendar.scss
@@ -3,50 +3,70 @@
     -webkit-border-horizontal-spacing: 0px;
     -webkit-border-vertical-spacing: 0px;
     background-color: rgba(0, 0, 0, 0);
-    border: 1px solid rgb(221, 221, 221);
+    border: 3px solid #f5cdbd;
     border-collapse: collapse;
     box-sizing: border-box;
     max-width: 100%;
     width: 100%;
   }
 
+  .calendar-heading {
+    margin-top: 20px;
+    color: gray;
+    letter-spacing: 0.20em;
+  }
+
+  a {
+    color:lightgray;
+  }
+
+  a:hover {
+    color:gray;
+  }
+
   tr {
     border-collapse: collapse;
+
+  }
+
+  tr.week {
+    letter-spacing: 0.20em;
+    background-color: #f5cdbd;
+    color: #f5ece4;
   }
 
   th {
     padding: 6px;
-    border-bottom: 2px solid rgb(221, 221, 221);
+    border-bottom: 2px solid #f5cdbd;
     border-collapse: collapse;
-    border-left: 1px solid rgb(221, 221, 221);
-    border-right: 1px solid rgb(221, 221, 221);
-    border-top: 0px none rgb(51, 51, 51);
+    border-left: 1px solid #f5cdbd;
+    border-right: 1px solid #f5cdbd;
     box-sizing: border-box;
-    text-align: left;
+    text-align: center;
   }
 
   td {
     padding: 6px;
     vertical-align: top;
     width: 14%;
-
-    border: 1px solid #ddd;
-    border-top-color: rgb(221, 221, 221);
+    border: 1px solid #f5cdbd;
+    border-top-color: #f5cdbd;
     border-top-style: solid;
     border-top-width: 1px;
-    border-right-color: rgb(221, 221, 221);
+    border-right-color: #f5cdbd;
     border-right-style: solid;
     border-right-width: 1px;
-    border-bottom-color: rgb(221, 221, 221);
+    border-bottom-color: #f5cdbd;
     border-bottom-style: solid;
     border-bottom-width: 1px;
-    border-left-color: rgb(221, 221, 221);
+    border-left-color: #f5cdbd;
     border-left-style: solid;
     border-left-width: 1px;
   }
 
   .day {
     height: 60px;
+    color: gray;
   }
 
   .wday-0 {}
@@ -58,7 +78,7 @@
   .wday-6 {}
 
   .today {
-    background: rgb(245, 250, 220)
+    background: #f5cdbd;
   }
 
   .past {}

--- a/app/javascript/src/users.scss
+++ b/app/javascript/src/users.scss
@@ -1,0 +1,40 @@
+.searching {
+  margin: 50px;
+  padding: 80px;
+}
+
+.user_search{
+  box-sizing: border-box;
+}
+.user_search input[type="search"]{
+  border: 1px solid #f5cdbd;
+  padding: 5px 8px;
+  border-radius: 20px;
+  height: 3.0em;
+  width: 245px;
+  overflow: hidden;
+  background: #f5cdbd;
+  color: gray;
+}
+
+.user_search input[type="search"]:focus {
+  outline: 0;
+  background: #f5cdbd;
+}
+
+.user_search input[type="submit"]{
+  cursor: pointer;
+  font-size: 1.3em;
+  border: none;
+  background: #bf9288;
+  color: #f5ece4;
+  outline : none;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.search {
+  letter-spacing: 0.20em;
+  color: #c76e54;
+  margin-bottom: 60px;
+}

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,13 +1,32 @@
 <% content_for(:title, 'mine') %>
 
-<h1><%= @user.nickname %> <%= @user.name %></h1>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="calendar col-10">
+      
+      <div class="text-right">
+      <% if logged_in? && current_user != @user %>
+        <% if current_user.following?(@user) %>
+          <%= render 'relationships/unfollow_button', user: @user %>
+        <% else %>
+          <%= render 'relationships/follow_button', user: @user %>
+        <% end %>
+      <% end %>
+      </div>
+    
+      <h1 class="calendar-name">
+        <%= @user.nickname %><%= @user.name %>
+      </h1>
 
-<%= month_calendar events: @diaries do |date, diaries| %>
-  <%= date.day %>
-
-  <% diaries.each do |diary| %>
-    <div>
-      <%= link_to diary.feeling, user_diary_path(@user, diary) %>
+      <%= month_calendar events: @diaries do |date, diaries| %>
+        <%= date.day %>
+      
+        <% diaries.each do |diary| %>
+          <div class="feeling">
+            <%= link_to diary.feeling, user_diary_path(@user, diary) %>
+          </div>
+        <% end %>
+      <% end %>
     </div>
-  <% end %>
-<% end %>
+  </div>
+</div>

--- a/app/views/followers/index.html.erb
+++ b/app/views/followers/index.html.erb
@@ -1,14 +1,27 @@
 <% content_for(:title, 'friend diary') %>
 
-<h1>friend's diary</h1>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="calendar col-10">
 
-<% @users.each do |user| %>
-  <h3><%= user.nickname %> <%= user.name %></h3>
-  <% @diaries = Diary.where(user_id: user.id) %>
-  <%= week_calendar events: @diaries do |date, diaries| %>
-    <%= date %>
-    <% diaries.each do |diary| %>
-      <%= link_to diary.feeling, user_diary_path(user, diary) %>
-    <% end %>
-  <% end %>
-<% end %>
+      <h1 class="calendar-name"><%= current_user.nickname %> friend's diary</h1>
+
+      <% @users.each do |user| %>
+        <h3 class="calendar-name">
+          <%= link_to user_diaries_path(user) do %>
+            <%= user.nickname %> <%= user.name %>
+          <% end %>
+        </h3>
+        <% @diaries = Diary.where(user_id: user.id) %>
+        <%= week_calendar events: @diaries do |date, diaries| %>
+          <%= date %>
+          <% diaries.each do |diary| %>
+            <div class="feeling">
+              <%= link_to diary.feeling, user_diary_path(user, diary) %>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/simple_calendar/_calendar.html.erb
+++ b/app/views/simple_calendar/_calendar.html.erb
@@ -5,7 +5,7 @@
     <%= link_to t('simple_calendar.next', default: 'Next'), calendar.url_for_next_view %>
   </div>
 
-  <table class="table table-striped">
+  <table class="table">
     <thead>
       <tr>
         <% date_range.slice(0, 7).each do |day| %>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,13 +1,13 @@
 <div class="simple-calendar">
   <div class="calendar-heading">
-    <%= link_to t('simple_calendar.previous', default: '<<'), calendar.url_for_previous_view %>
+    <%= link_to '<<', calendar.url_for_previous_view %>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
-    <%= link_to t('simple_calendar.next', default: '>>'), calendar.url_for_next_view %>
+    <%= link_to '>>', calendar.url_for_next_view %>
   </div>
 
-  <table class="table table-sm table-striped ">
+  <table class="table table-sm">
     <thead>
-      <tr>
+      <tr class="week">
         <% date_range.slice(0, 7).each do |day| %>
           <th><%= t('date.abbr_day_names')[day.wday] %></th>
         <% end %>

--- a/app/views/simple_calendar/_week_calendar.html.erb
+++ b/app/views/simple_calendar/_week_calendar.html.erb
@@ -1,12 +1,12 @@
 <div class="simple-calendar">
-  <div class="calendar-heading">
+  <div class="calendar-heading-week">
     <%= link_to t('simple_calendar.previous', default: '<<'), calendar.url_for_previous_view %>
     <%= link_to t('simple_calendar.next', default: '>>'), calendar.url_for_next_view %>
   </div>
 
-  <table class="table table-sm table-striped">
+  <table class="table table-sm">
     <thead>
-      <tr>
+      <tr class="week">
         <% date_range.slice(0, 7).each do |day| %>
           <th><%= t('date.abbr_day_names')[day.wday] %></th>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,16 +1,15 @@
 <% content_for(:title, 'User search') %>
 
-<h1>search</h1>
-
-<p id="notice"><%= notice %></p>
-
-<div class="container pt-3">
-  <div class="row">
-    <div class="col-lg-10 offset-lg-1">
-      <%= search_form_for @q, url: search_path do |f| %>
-        <%= f.search_field :name_cont, placeholder: 'user name', required: true %>
-        <%= f.submit class: 'btn btn-primary' %>
-      <% end %>
+<div class="container">
+  <div class="row justify-content-center">
+    <div class="searching col-10">
+      <h1 class="search"><%= current_user.nickname %> search</h1>
+      <div class="text-center">
+        <%= search_form_for @q, url: search_path do |f| %>
+          <%= f.search_field :name_cont, placeholder: 'user name', required: true %>
+          <%= f.submit class: 'btn btn-primary' %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 概要

simple_calendarの初期のレイアウトのままになっていたので、class属性を追加したり、scssを追加して、レイアウトを整えました。一覧画面から詳細画面に遷移するので、詳細画面とレイアウトを合わせました。
また友達の日記一覧のページも修正しました。
友達検索ページのレイアウトも変更しました。

## 影響範囲

自分の日記一覧、各ユーザーの日記一覧、友達の日記一覧、友達検索ページ


## コメント

友達の各日記の一覧にフォロー、アンフォローのボタンを設置しました。ボタンの場所がいまいちなのと、Bootstrap感がまだ残っているので、修正します。

自分の日記一覧ページ
[![Image from Gyazo](https://i.gyazo.com/55c7f236a5cddbb5daf8d7d9c2cb80df.png)](https://gyazo.com/55c7f236a5cddbb5daf8d7d9c2cb80df)

友達の日記一覧ページ
[![Image from Gyazo](https://i.gyazo.com/28c371e09a4f036ee545b55536720090.png)](https://gyazo.com/28c371e09a4f036ee545b55536720090)

各ユーザーの日記一覧ページ(フォローボタン設置)
[![Image from Gyazo](https://i.gyazo.com/f7c4ceba44687be17ca048ca919488dd.png)](https://gyazo.com/f7c4ceba44687be17ca048ca919488dd)

友達検索ページ
[![Image from Gyazo](https://i.gyazo.com/fe0b4842ed5c27788f01a9ea2f5cd5fd.png)](https://gyazo.com/fe0b4842ed5c27788f01a9ea2f5cd5fd)