### PR TITLE
感情絵文字のフォームにタブを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,6 @@ gem "jquery-rails"
 
 # グラフ
 gem "chartkick"
+
+# フォーム
+gem 'simple_form'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,9 @@ GEM
     semantic_range (3.0.0)
     simple_calendar (2.4.2)
       rails (>= 3.0)
+    simple_form (5.1.0)
+      actionpack (>= 5.2)
+      activemodel (>= 5.2)
     sorcery (0.16.1)
       bcrypt (~> 3.1)
       oauth (~> 0.5, >= 0.5.5)
@@ -330,6 +333,7 @@ DEPENDENCIES
   sass-rails (>= 6)
   seed-fu
   simple_calendar (~> 2.4)
+  simple_form
   sorcery
   spring
   tzinfo-data

--- a/app/javascript/src/diaries.scss
+++ b/app/javascript/src/diaries.scss
@@ -10,15 +10,17 @@ label img {
   padding: 5px;
  }
 
-/* 未選択の場合、絵文字の大きさが小さい */
+/* 未選択の場合の絵文字 */
 input[type="radio"] + label img {
   width: 30px;
   height: 30px;
 }
-/* 選択済みの場合、絵文字の大きさが大きい */
+/* 選択済みの場合の絵文字、背景色がつく */
 input[type="radio"]:checked + label img {
-  width: 50px;
-  height: 50px;
+  width: 30px;
+  height: 30px;
+  background: #c76e54;
+  border-radius: 20px;
 }
 
 /* 詳細画面の日付 */
@@ -140,4 +142,51 @@ h3.calendar-name {
 /* 日記の枠の色 */
 .table > thead > tr > th{
   border:1px solid #f5cdbd;
+}
+
+/* 感情絵文字のタブ */
+.area {
+  width: auto;
+  margin: auto;
+  flex-wrap: wrap;
+  display: flex;
+}
+ 
+/* ６分割するタブの設定 */
+.tab_class {
+  width: calc(100%/6);
+  height: 50px;
+  background-color: #f5ece4;
+  line-height: 50px;
+  font-size: 15px;
+  text-align: center;
+  display: block;
+  float: left;
+  order: -1;
+}
+
+input[name="tab_name"] {
+  display: none;
+}
+
+/* タブをチェックしている部分のレイアウト */
+input:checked + .tab_class {
+  background-color: #f5cdbd;
+  color: #c76e54;
+}
+ 
+/* タブのレイアウト */
+.content_class {
+  display: none;
+  width: 100%;
+  text-align: center;
+  padding-top: 20px;
+}
+ 
+input:checked + .tab_class + .content_class {
+  display: block;
+}
+
+.form-group {
+  padding-bottom: 2px;
 }

--- a/app/javascript/src/header_footer.scss
+++ b/app/javascript/src/header_footer.scss
@@ -53,6 +53,7 @@
   transition: .4s;
 }
 
+/* 日記新規作成のボタン、ホバー時 */
 .btn-circle-border:hover {
   border-style: dashed;
   color: rgba(255, 255, 255, 0.47);

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -22,6 +22,8 @@ class Diary < ApplicationRecord
   # validateに下記で定義したメソッドを設定
   validate :start_time_cannot_be_in_the_future
 
+  validates :start_time, uniqueness: { scope: :user }
+
   # 最終更新日から30日分の日記の感情だけを表示するためのスコープ
   scope :current_month, -> { where(start_time: Time.now - 30.days..Time.now) }
 

--- a/app/views/diaries/_form.html.erb
+++ b/app/views/diaries/_form.html.erb
@@ -1,478 +1,485 @@
-<%= form_with model: diary, url: url, local: true do |f| %>
-  <%= render 'shared/error_messages', object: f.object %>
+<%= simple_form_for diary, url: url, local: true do |f| %>
   
-  <div class="form-group row">
-    <%= f.label :start_time %>
-    <%= f.date_field :start_time, value: Time.now.strftime("%Y-%m-%d"), class: 'form-control' %>
+  <div class="form-group">
+    <%= f.input :start_time, as: :date, html5: true,
+        input_html: { value: Time.now.strftime("%Y-%m-%d") } ,
+        class: 'form-control' %>
   </div>
   
   <div class="form-group">
-    <div class="smile">
-      <%= f.radio_button :feeling, '😀', id: 'diary_feeling1', checked: 'checked' %>
-      <%= f.label :feeling1, '😀' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_1.svg' %>">
-      <% end %>
+    <%= f.label :feeling %>
+  <div class="area">
+  <input type="radio" name="tab_name" id="tab1" checked>
+    <label class="tab_class" for="tab1">😄</label>
+      <div class="content_class">
+        <p>
+          <%= f.radio_button :feeling, '😀', id: 'diary_feeling1', checked: 'checked' %>
+          <%= f.label :feeling1, '😀' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_1.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😃', id: 'diary_feeling2' %>
-      <%= f.label :feeling2, '😃' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_2.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😃', id: 'diary_feeling2' %>
+          <%= f.label :feeling2, '😃' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_2.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😄', id: 'diary_feeling3' %>
-      <%= f.label :feeling3, '😄' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_3.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😄', id: 'diary_feeling3' %>
+          <%= f.label :feeling3, '😄' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_3.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😁', id: 'diary_feeling4' %>
-      <%= f.label :feeling4, '😁' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_4.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😁', id: 'diary_feeling4' %>
+          <%= f.label :feeling4, '😁' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_4.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😆', id: 'diary_feeling5' %>
-      <%= f.label :feeling5, '😆' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_5.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😆', id: 'diary_feeling5' %>
+          <%= f.label :feeling5, '😆' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_5.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😅', id: 'diary_feeling6' %>
-      <%= f.label :feeling6, '😅' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_6.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😅', id: 'diary_feeling6' %>
+          <%= f.label :feeling6, '😅' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_6.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😂', id: 'diary_feeling7' %>
-      <%= f.label :feeling7, '😂' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_7.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😂', id: 'diary_feeling7' %>
+          <%= f.label :feeling7, '😂' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_7.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤣', id: 'diary_feeling8' %>
-      <%= f.label :feeling8, '🤣' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_8.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤣', id: 'diary_feeling8' %>
+          <%= f.label :feeling8, '🤣' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_8.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😉', id: 'diary_feeling9' %>
-      <%= f.label :feeling9, '😉' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_9.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😉', id: 'diary_feeling9' %>
+          <%= f.label :feeling9, '😉' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_9.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😊', id: 'diary_feeling10' %>
-      <%= f.label :feeling10, '😊' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_10.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😊', id: 'diary_feeling10' %>
+          <%= f.label :feeling10, '😊' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_10.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😇', id: 'diary_feeling11' %>
-      <%= f.label :feeling11, '😇' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_11.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😇', id: 'diary_feeling11' %>
+          <%= f.label :feeling11, '😇' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_11.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤩', id: 'diary_feeling12' %>
-      <%= f.label :feeling12, '🤩' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_12.svg' %>">
-      <% end %>
-    </div>
+          <%= f.radio_button :feeling, '🤗', id: 'diary_feeling19' %>
+          <%= f.label :feeling19, '🤗' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_19.svg' %>">
+          <% end %>
+          
+          <%= f.radio_button :feeling, '😋', id: 'diary_feeling20' %>
+          <%= f.label :feeling20, '😋' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_20.svg' %>">
+          <% end %>
 
-    <div class="love">
-      <%= f.radio_button :feeling, '🥰', id: 'diary_feeling13' %>
-      <%= f.label :feeling13, '🥰' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_13.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😝', id: 'diary_feeling24' %>
+          <%= f.label :feeling24, '😝' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_24.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😎', id: 'diary_feeling27' %>
+          <%= f.label :feeling27, '😎' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_27.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '🙂', id: 'diary_feeling31' %>
+          <%= f.label :feeling31, '🙂' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_31.svg' %>">
+          <% end %>
+
+        </p>
+      </div>
+  
+  <input type="radio" name="tab_name" id="tab2" >
+    <label class="tab_class" for="tab2">🥳</label>
+      <div class="content_class">
+        <p>
+          <%= f.radio_button :feeling, '🤩', id: 'diary_feeling12' %>
+          <%= f.label :feeling12, '🤩' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_12.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '🥰', id: 'diary_feeling13' %>
+          <%= f.label :feeling13, '🥰' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_13.svg' %>">
+          <% end %>
       
-      <%= f.radio_button :feeling, '😍', id: 'diary_feeling14' %>
-      <%= f.label :feeling14, '😍' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_14.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😍', id: 'diary_feeling14' %>
+          <%= f.label :feeling14, '😍' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_14.svg' %>">
+          <% end %>
       
-      <%= f.radio_button :feeling, '😘', id: 'diary_feeling15' %>
-      <%= f.label :feeling15, '😘' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_15.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😘', id: 'diary_feeling15' %>
+          <%= f.label :feeling15, '😘' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_15.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😗', id: 'diary_feeling16' %>
-      <%= f.label :feeling16, '😗' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_16.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😗', id: 'diary_feeling16' %>
+          <%= f.label :feeling16, '😗' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_16.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😚', id: 'diary_feeling17' %>
-      <%= f.label :feeling17, '😚' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_17.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😚', id: 'diary_feeling17' %>
+          <%= f.label :feeling17, '😚' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_17.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😙', id: 'diary_feeling18' %>
-      <%= f.label :feeling18, '😙' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_18.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😙', id: 'diary_feeling18' %>
+          <%= f.label :feeling18, '😙' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_18.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤗', id: 'diary_feeling19' %>
-      <%= f.label :feeling19, '🤗' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_19.svg' %>">
-      <% end %>
-    </div>
+          <%= f.radio_button :feeling, '😛', id: 'diary_feeling21' %>
+          <%= f.label :feeling21, '😛' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_21.svg' %>">
+          <% end %>
 
-    <div class="happy">
-      <%= f.radio_button :feeling, '😋', id: 'diary_feeling20' %>
-      <%= f.label :feeling20, '😋' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_20.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😜', id: 'diary_feeling22' %>
+          <%= f.label :feeling22, '😜' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_22.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😛', id: 'diary_feeling21' %>
-      <%= f.label :feeling21, '😛' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_21.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤪', id: 'diary_feeling23' %>
+          <%= f.label :feeling23, '🤪' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_23.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😜', id: 'diary_feeling22' %>
-      <%= f.label :feeling22, '😜' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_22.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤑', id: 'diary_feeling25' %>
+          <%= f.label :feeling25, '🤑' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_25.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤪', id: 'diary_feeling23' %>
-      <%= f.label :feeling23, '🤪' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_23.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🥳', id: 'diary_feeling26' %>
+          <%= f.label :feeling26, '🥳' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_26.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😝', id: 'diary_feeling24' %>
-      <%= f.label :feeling24, '😝' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_24.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤤', id: 'diary_feeling28' %>
+          <%= f.label :feeling28, '🤤' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_28.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤑', id: 'diary_feeling25' %>
-      <%= f.label :feeling25, '🤑' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_25.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😳', id: 'diary_feeling29' %>
+          <%= f.label :feeling29, '😳' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_29.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🥳', id: 'diary_feeling26' %>
-      <%= f.label :feeling26, '🥳' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_26.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤓', id: 'diary_feeling37' %>
+          <%= f.label :feeling37, '🤓' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_37.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😎', id: 'diary_feeling27' %>
-      <%= f.label :feeling27, '😎' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_27.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😌', id: 'diary_feeling38' %>
+          <%= f.label :feeling38, '😌' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_38.svg' %>">
+          <% end %>
+        
+        </p>
+      </div>
+  
+  <input type="radio" name="tab_name" id="tab3" >
+    <label class="tab_class" for="tab3">🤔</label>
+      <div class="content_class">
+        <p>
+          <%= f.radio_button :feeling, '😲', id: 'diary_feeling30' %>
+          <%= f.label :feeling30, '😲' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_30.svg' %>">
+          <% end %>
+          
+          <%= f.radio_button :feeling, '😬', id: 'diary_feeling36' %>
+          <%= f.label :feeling36, '😬' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_36.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤤', id: 'diary_feeling28' %>
-      <%= f.label :feeling28, '🤤' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_28.svg' %>">
-      <% end %>
-    </div>
-
-    <div class="supprised">
-      <%= f.radio_button :feeling, '😳', id: 'diary_feeling29' %>
-      <%= f.label :feeling29, '😳' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_29.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😲', id: 'diary_feeling30' %>
-      <%= f.label :feeling30, '😲' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_30.svg' %>">
-      <% end %>
-    </div>
-
-    <div class="porkerface">
-      <%= f.radio_button :feeling, '🙂', id: 'diary_feeling31' %>
-      <%= f.label :feeling31, '🙂' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_31.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🙃', id: 'diary_feeling32' %>
-      <%= f.label :feeling32, '🙃' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_32.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😐', id: 'diary_feeling33' %>
-      <%= f.label :feeling33, '😐' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_33.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😶', id: 'diary_feeling34' %>
-      <%= f.label :feeling34, '😶' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_34.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😑', id: 'diary_feeling35' %>
-      <%= f.label :feeling35, '😑' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_35.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😬', id: 'diary_feeling36' %>
-      <%= f.label :feeling36, '😬' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_36.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🤓', id: 'diary_feeling37' %>
-      <%= f.label :feeling37, '🤓' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_37.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😌', id: 'diary_feeling38' %>
-      <%= f.label :feeling38, '😌' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_38.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😕', id: 'diary_feeling39' %>
-      <%= f.label :feeling39, '😕' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_39.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😟', id: 'diary_feeling40' %>
-      <%= f.label :feeling40, '😟' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_40.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🙁', id: 'diary_feeling41' %>
-      <%= f.label :feeling41, '🙁' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_41.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😮', id: 'diary_feeling42' %>
-      <%= f.label :feeling42, '😮' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_42.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😯', id: 'diary_feeling43' %>
-      <%= f.label :feeling43, '😯' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_43.svg' %>">
-      <% end %>
-    </div>
-
-    <div class="doubt">
-      <%= f.radio_button :feeling, '🤭', id: 'diary_feeling44' %>
-      <%= f.label :feeling44, '🤭' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_44.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤭', id: 'diary_feeling44' %>
+          <%= f.label :feeling44, '🤭' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_44.svg' %>">
+          <% end %>
       
-      <%= f.radio_button :feeling, '🤫', id: 'diary_feeling45' %>
-      <%= f.label :feeling45, '🤫' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_45.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤫', id: 'diary_feeling45' %>
+          <%= f.label :feeling45, '🤫' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_45.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤔', id: 'diary_feeling46' %>
-      <%= f.label :feeling46, '🤔' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_46.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤔', id: 'diary_feeling46' %>
+          <%= f.label :feeling46, '🤔' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_46.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤐', id: 'diary_feeling47' %>
-      <%= f.label :feeling47, '🤐' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_47.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤐', id: 'diary_feeling47' %>
+          <%= f.label :feeling47, '🤐' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_47.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤨', id: 'diary_feeling48' %>
-      <%= f.label :feeling48, '🤨' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_48.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤨', id: 'diary_feeling48' %>
+          <%= f.label :feeling48, '🤨' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_48.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🧐', id: 'diary_feeling49' %>
-      <%= f.label :feeling49, '🧐' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_49.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🧐', id: 'diary_feeling49' %>
+          <%= f.label :feeling49, '🧐' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_49.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😏', id: 'diary_feeling50' %>
-      <%= f.label :feeling50, '😏' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_50.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😏', id: 'diary_feeling50' %>
+          <%= f.label :feeling50, '😏' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_50.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😒', id: 'diary_feeling51' %>
-      <%= f.label :feeling51, '😒' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_51.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😒', id: 'diary_feeling51' %>
+          <%= f.label :feeling51, '😒' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_51.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🙄', id: 'diary_feeling52' %>
-      <%= f.label :feeling52, '🙄' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_52.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🙃', id: 'diary_feeling32' %>
+          <%= f.label :feeling32, '🙃' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_32.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤥', id: 'diary_feeling53' %>
-      <%= f.label :feeling53, '🤥' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_53.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🙄', id: 'diary_feeling52' %>
+          <%= f.label :feeling52, '🙄' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_52.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😔', id: 'diary_feeling54' %>
-      <%= f.label :feeling54, '😔' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_54.svg' %>">
-      <% end %>
-    </div>
+          <%= f.radio_button :feeling, '🤥', id: 'diary_feeling53' %>
+          <%= f.label :feeling53, '🤥' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_53.svg' %>">
+          <% end %>
 
-    <div class="tired">
-      <%= f.radio_button :feeling, '😪', id: 'diary_feeling55' %>
-      <%= f.label :feeling55, '😪' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_55.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🥺', id: 'diary_feeling67' %>
+          <%= f.label :feeling67, '🥺' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_67.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😴', id: 'diary_feeling56' %>
-      <%= f.label :feeling56, '😴' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_56.svg' %>">
-      <% end %>
+        </p>
+      </div>
 
-      <%= f.radio_button :feeling, '😵', id: 'diary_feeling57' %>
-      <%= f.label :feeling57, '😵' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_57.svg' %>">
-      <% end %>
 
-      <%= f.radio_button :feeling, '🤯', id: 'diary_feeling58' %>
-      <%= f.label :feeling58, '🤯' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_58.svg' %>">
-      <% end %>
-    </div>
+  <input type="radio" name="tab_name" id="tab4" >
+    <label class="tab_class" for="tab4">😢</label>
+      <div class="content_class">
+        <p>
+          <%= f.radio_button :feeling, '😥', id: 'diary_feeling72' %>
+          <%= f.label :feeling72, '😥' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_72.svg' %>">
+          <% end %>
 
-    <div class="sick">
-      <%= f.radio_button :feeling, '😷', id: 'diary_feeling59' %>
-      <%= f.label :feeling59, '😷' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_59.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🤕', id: 'diary_feeling60' %>
-      <%= f.label :feeling60, '🤕' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_60.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🤢', id: 'diary_feeling61' %>
-      <%= f.label :feeling61, '🤢' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_61.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🤮', id: 'diary_feeling62' %>
-      <%= f.label :feeling62, '🤮' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_62.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🤧', id: 'diary_feeling63' %>
-      <%= f.label :feeling63, '🤧' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_63.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🥵', id: 'diary_feeling64' %>
-      <%= f.label :feeling64, '🥵' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_64.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🥶', id: 'diary_feeling65' %>
-      <%= f.label :feeling65, '🥶' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_65.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '🥴', id: 'diary_feeling66' %>
-      <%= f.label :feeling66, '🥴' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_66.svg' %>">
-      <% end %>
-    </div>
-
-    <div class="worried">
-      <%= f.radio_button :feeling, '🥺', id: 'diary_feeling67' %>
-      <%= f.label :feeling67, '🥺' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_67.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😦', id: 'diary_feeling68' %>
-      <%= f.label :feeling68, '😦' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_68.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😧', id: 'diary_feeling69' %>
-      <%= f.label :feeling69, '😧' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_69.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😨', id: 'diary_feeling70' %>
-      <%= f.label :feeling70, '😨' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_70.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😰', id: 'diary_feeling71' %>
-      <%= f.label :feeling71, '😰' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_71.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😥', id: 'diary_feeling72' %>
-      <%= f.label :feeling72, '😥' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_72.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😱', id: 'diary_feeling73' %>
-      <%= f.label :feeling73, '😱' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_73.svg' %>">
-      <% end %>
-
-      <%= f.radio_button :feeling, '😓', id: 'diary_feeling74' %>
-      <%= f.label :feeling74, '😓' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_74.svg' %>">
-      <% end %>
-    </div>
-
-    <div class="cried">
-      <%= f.radio_button :feeling, '😢', id: 'diary_feeling75' %>
-      <%= f.label :feeling75, '😢' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_75.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😢', id: 'diary_feeling75' %>
+          <%= f.label :feeling75, '😢' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_75.svg' %>">
+          <% end %>
       
-      <%= f.radio_button :feeling, '😭', id: 'diary_feeling76' %>
-      <%= f.label :feeling76, '😭' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_76.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😭', id: 'diary_feeling76' %>
+          <%= f.label :feeling76, '😭' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_76.svg' %>">
+          <% end %>
+  
+          <%= f.radio_button :feeling, '😓', id: 'diary_feeling74' %>
+          <%= f.label :feeling74, '😓' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_74.svg' %>">
+          <% end %>
+      
+          <%= f.radio_button :feeling, '😔', id: 'diary_feeling54' %>
+          <%= f.label :feeling54, '😔' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_54.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😖', id: 'diary_feeling77' %>
-      <%= f.label :feeling77, '😖' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_77.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😣', id: 'diary_feeling78' %>
+          <%= f.label :feeling78, '😣' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_78.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😣', id: 'diary_feeling78' %>
-      <%= f.label :feeling78, '😣' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_78.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😩', id: 'diary_feeling80' %>
+          <%= f.label :feeling80, '😩' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_80.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😞', id: 'diary_feeling79' %>
-      <%= f.label :feeling79, '😞' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_79.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😵', id: 'diary_feeling57' %>
+          <%= f.label :feeling57, '😵' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_57.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😩', id: 'diary_feeling80' %>
-      <%= f.label :feeling80, '😩' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_80.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '😷', id: 'diary_feeling59' %>
+          <%= f.label :feeling59, '😷' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_59.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😫', id: 'diary_feeling81' %>
-      <%= f.label :feeling81, '😫' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_81.svg' %>">
-      <% end %>
-    </div>
+          <%= f.radio_button :feeling, '🤕', id: 'diary_feeling60' %>
+          <%= f.label :feeling60, '🤕' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_60.svg' %>">
+          <% end %>
 
-    <div class="angry">
-      <%= f.radio_button :feeling, '😤', id: 'diary_feeling82' %>
-      <%= f.label :feeling82, '😤' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_82.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤢', id: 'diary_feeling61' %>
+          <%= f.label :feeling61, '🤢' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_61.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😡', id: 'diary_feeling83' %>
-      <%= f.label :feeling83, '😡' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_83.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤮', id: 'diary_feeling62' %>
+          <%= f.label :feeling62, '🤮' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_62.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😠', id: 'diary_feeling84' %>
-      <%= f.label :feeling84, '😠' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_84.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🤧', id: 'diary_feeling63' %>
+          <%= f.label :feeling63, '🤧' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_63.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '🤬', id: 'diary_feeling85' %>
-      <%= f.label :feeling85, '🤬' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_85.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🥵', id: 'diary_feeling64' %>
+          <%= f.label :feeling64, '🥵' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_64.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '😈', id: 'diary_feeling86' %>
-      <%= f.label :feeling86, '😈' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_86.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🥶', id: 'diary_feeling65' %>
+          <%= f.label :feeling65, '🥶' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_65.svg' %>">
+          <% end %>
 
-      <%= f.radio_button :feeling, '👿', id: 'diary_feeling87' %>
-      <%= f.label :feeling87, '👿' do %>
-        <img src="<%= asset_pack_path 'media/images/emoji_87.svg' %>">
-      <% end %>
+          <%= f.radio_button :feeling, '🥴', id: 'diary_feeling66' %>
+          <%= f.label :feeling66, '🥴' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_66.svg' %>">
+          <% end %>
+        </p>
+      </div>
+    
+  <input type="radio" name="tab_name" id="tab5" >
+    <label class="tab_class" for="tab5">😫</label>
+      <div class="content_class">
+        <p>
+          <%= f.radio_button :feeling, '😐', id: 'diary_feeling33' %>
+          <%= f.label :feeling33, '😐' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_33.svg' %>">
+          <% end %>
+  
+          <%= f.radio_button :feeling, '😶', id: 'diary_feeling34' %>
+          <%= f.label :feeling34, '😶' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_34.svg' %>">
+          <% end %>
+  
+          <%= f.radio_button :feeling, '😑', id: 'diary_feeling35' %>
+          <%= f.label :feeling35, '😑' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_35.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😕', id: 'diary_feeling39' %>
+          <%= f.label :feeling39, '😕' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_39.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😟', id: 'diary_feeling40' %>
+          <%= f.label :feeling40, '😟' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_40.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '🙁', id: 'diary_feeling41' %>
+          <%= f.label :feeling41, '🙁' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_41.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😖', id: 'diary_feeling77' %>
+          <%= f.label :feeling77, '😖' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_77.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😫', id: 'diary_feeling81' %>
+          <%= f.label :feeling81, '😫' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_81.svg' %>">
+          <% end %>
+          
+          <%= f.radio_button :feeling, '😪', id: 'diary_feeling55' %>
+          <%= f.label :feeling55, '😪' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_55.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😴', id: 'diary_feeling56' %>
+          <%= f.label :feeling56, '😴' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_56.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😦', id: 'diary_feeling68' %>
+          <%= f.label :feeling68, '😦' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_68.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😧', id: 'diary_feeling69' %>
+          <%= f.label :feeling69, '😧' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_69.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😨', id: 'diary_feeling70' %>
+          <%= f.label :feeling70, '😨' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_70.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😰', id: 'diary_feeling71' %>
+          <%= f.label :feeling71, '😰' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_71.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😱', id: 'diary_feeling73' %>
+          <%= f.label :feeling73, '😱' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_73.svg' %>">
+          <% end %>
+
+        </p>
+      </div>
+    
+  <input type="radio" name="tab_name" id="tab6" >
+    <label class="tab_class" for="tab6">😤</label>
+      <div class="content_class">
+        <p>
+          <%= f.radio_button :feeling, '🤯', id: 'diary_feeling58' %>
+          <%= f.label :feeling58, '🤯' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_58.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😤', id: 'diary_feeling82' %>
+          <%= f.label :feeling82, '😤' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_82.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😡', id: 'diary_feeling83' %>
+          <%= f.label :feeling83, '😡' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_83.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😠', id: 'diary_feeling84' %>
+          <%= f.label :feeling84, '😠' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_84.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '🤬', id: 'diary_feeling85' %>
+          <%= f.label :feeling85, '🤬' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_85.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '😈', id: 'diary_feeling86' %>
+          <%= f.label :feeling86, '😈' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_86.svg' %>">
+          <% end %>
+
+          <%= f.radio_button :feeling, '👿', id: 'diary_feeling87' %>
+          <%= f.label :feeling87, '👿' do %>
+            <img src="<%= asset_pack_path 'media/images/emoji_87.svg' %>">
+          <% end %>
+          
+        </p>
+      </div>
     </div>
   </div>
 
   <div class="form-group">
-    <%= f.label :body %>
-    <%= f.text_field :body, class: 'form-control' %>
+    <%= f.input :body, class: 'form-control', hint: '絵文字でどんな一日だったのか表してみましょう！ 例:🎂🎉🎁🥂' %>
   </div>
 
 
   <div class="submit text-center">
-    <%= f.submit class: "btn btn-primary" %>
+    <%= f.button :submit, class: "btn btn-primary" %>
   </div>
 
 <% end %>

--- a/app/views/diaries/edit.html.erb
+++ b/app/views/diaries/edit.html.erb
@@ -4,10 +4,10 @@
   <div class="row justify-content-center">
     <div class="resulting col-10">
       
-      <h1 class="result"><%= current_user.nickname %> write a diary</h1>
+      <h1 class="result"><%= current_user.nickname %> edit a diary</h1>
       
       <div class="row justify-content-center">
-        <div class="register col-6">
+        <div class="register col-10">
           <%= render 'form', { diary: @diary, url: user_diary_path } %>
         </div>
       </div>

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -7,11 +7,10 @@
       <h1 class="result"><%= current_user.nickname %> write a diary</h1>
       
       <div class="row justify-content-center">
-        <div class="register col-6">
+        <div class="register col-10">
           <%= render 'form', { diary: @diary, url: user_diaries_path } %>
         </div>
       </div>
     </div>
   </div>
 </div>
-

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -7,7 +7,8 @@
       <h1 class="result">📖 <%= t '.title' %></h1>
       <div class="row justify-content-center">
         <div class="register col-6">
-          <%= form_with url: login_path, method: :post, local: true do |f| %>
+        <%= form_with url: login_path, method: :post, local: true do |f| %>
+          
             <div class="form-group">
               <%= f.label :name, User.human_attribute_name(:name) %>
               <%= f.text_field :name, class: "form-control" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -8,23 +8,19 @@
       
       <div class="row justify-content-center">
         <div class="register col-6">
-        <%= form_with model: @user, local: true do |f| %>
-          <%= render 'shared/error_messages', object: f.object %>
+        <%= simple_form_for @user, local: true do |f| %>
           <div class="form-group">
-            <%= f.label :name %>
-            <%= f.text_field :name, class: 'form-control' %>
+            <%= f.input :name, class: 'form-control' %>
           </div>
           <div class="form-group">
-            <%= f.label :password %>
-            <%= f.password_field :password, class: "form-control" %>
+            <%= f.input :password, class: "form-control" %>
           </div>
           <div class="form-group">
-            <%= f.label :password_confirmation %>
-            <%= f.password_field :password_confirmation, class: "form-control" %>
+            <%= f.input :password_confirmation, class: "form-control" %>
           </div>
 
           <div class="text-center">
-            <%= f.submit t('defaults.register'), class: 'btn btn-primary' %>
+            <%= f.button :submit, class: 'btn btn-primary' %>
           </div>
         <% end %>
         <div class='text-center'>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/heartcombo/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+                            hint_class: :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -1,0 +1,434 @@
+# frozen_string_literal: true
+
+# Please do not make direct changes to this file!
+# This generator is maintained by the community around simple_form-bootstrap:
+# https://github.com/rafaelfranca/simple_form-bootstrap
+# All future development, tests, and organization should happen there.
+# Background history: https://github.com/heartcombo/simple_form/issues/1561
+
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/heartcombo/simple_form#custom-components
+# to know more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'form-check-label'
+
+  # How the label text should be generated altogether with the required text.
+  config.label_text = proc { |label, _required| label.to_s }
+  # config.label_text = lambda { |label, required, explicit_label| "#{label} #{required}" }
+
+  # Define the way to render check boxes / radio buttons with labels.
+  config.boolean_style = :inline
+
+  # You can wrap each item in a collection of radio/check boxes with a tag
+  config.item_wrapper_tag = :div
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  config.include_default_input_wrapper_class = false
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'alert alert-danger'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # :to_sentence to list all errors for each field.
+  config.error_method = :to_sentence
+
+  # add validation classes to `input_field`
+  config.input_field_error_class = 'is-invalid'
+  config.input_field_valid_class = 'is-valid'
+
+  # vertical forms
+  #
+  # vertical default_wrapper
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical input for boolean
+  config.wrappers :vertical_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
+      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'form-check-label'
+      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # vertical input for radio buttons and check boxes
+  config.wrappers :vertical_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical input for inline radio buttons and check boxes
+  config.wrappers :vertical_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical file input
+  config.wrappers :vertical_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label
+    b.use :input, class: 'form-control-file', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical multi select
+  config.wrappers :vertical_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label
+    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
+      ba.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    end
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical range input
+  config.wrappers :vertical_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label
+    b.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # horizontal forms
+  #
+  # horizontal default_wrapper
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal input for boolean
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper tag: 'label', class: 'col-sm-3' do |ba|
+      ba.use :label_text
+    end
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |wr|
+      wr.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
+        bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+        bb.use :label, class: 'form-check-label'
+        bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+        bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      end
+    end
+  end
+
+  # horizontal input for radio buttons and check boxes
+  config.wrappers :horizontal_collection, item_wrapper_class: 'form-check', item_label_class: 'form-check-label', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 col-form-label pt-0'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal input for inline radio buttons and check boxes
+  config.wrappers :horizontal_collection_inline, item_wrapper_class: 'form-check form-check-inline', item_label_class: 'form-check-label', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 col-form-label pt-0'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal file input
+  config.wrappers :horizontal_file, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal multi select
+  config.wrappers :horizontal_multi_select, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
+        bb.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+      end
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal range input
+  config.wrappers :horizontal_range, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # inline forms
+  #
+  # inline default_wrapper
+  config.wrappers :inline_form, tag: 'span', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'sr-only'
+
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # inline input for boolean
+  config.wrappers :inline_boolean, tag: 'span', class: 'form-check mb-2 mr-sm-2', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: 'form-check-label'
+    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # bootstrap custom forms
+  #
+  # custom input for boolean
+  config.wrappers :custom_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-checkbox' do |bb|
+      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'custom-control-label'
+      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # custom input switch for boolean
+  config.wrappers :custom_boolean_switch, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-switch' do |bb|
+      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'custom-control-label'
+      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # custom input for radio buttons and check boxes
+  config.wrappers :custom_collection, item_wrapper_class: 'custom-control', item_label_class: 'custom-control-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom input for inline radio buttons and check boxes
+  config.wrappers :custom_collection_inline, item_wrapper_class: 'custom-control custom-control-inline', item_label_class: 'custom-control-label', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom file input
+  config.wrappers :custom_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label
+    b.wrapper :custom_file_wrapper, tag: 'div', class: 'custom-file' do |ba|
+      ba.use :input, class: 'custom-file-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :label, class: 'custom-file-label'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    end
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom multi select
+  config.wrappers :custom_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label
+    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
+      ba.use :input, class: 'custom-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    end
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom range input
+  config.wrappers :custom_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label
+    b.use :input, class: 'custom-range', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # Input Group - custom component
+  # see example app and config at https://github.com/rafaelfranca/simple_form-bootstrap
+  # config.wrappers :input_group, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  #   b.use :html5
+  #   b.use :placeholder
+  #   b.optional :maxlength
+  #   b.optional :minlength
+  #   b.optional :pattern
+  #   b.optional :min_max
+  #   b.optional :readonly
+  #   b.use :label
+  #   b.wrapper :input_group_tag, tag: 'div', class: 'input-group' do |ba|
+  #     ba.optional :prepend
+  #     ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+  #     ba.optional :append
+  #   end
+  #   b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+  #   b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  # end
+
+  # Floating Labels form
+  #
+  # floating labels default_wrapper
+  config.wrappers :floating_labels_form, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom multi select
+  config.wrappers :floating_labels_select, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :input, class: 'custom-select', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :vertical_form
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  config.wrapper_mappings = {
+    boolean: :vertical_boolean,
+    check_boxes: :vertical_collection,
+    date: :vertical_multi_select,
+    datetime: :vertical_multi_select,
+    file: :vertical_file,
+    radio_buttons: :vertical_collection,
+    range: :vertical_range,
+    time: :vertical_multi_select
+  }
+
+  # enable custom form wrappers
+  # config.wrapper_mappings = {
+  #   boolean:       :custom_boolean,
+  #   check_boxes:   :custom_collection,
+  #   date:          :custom_multi_select,
+  #   datetime:      :custom_multi_select,
+  #   file:          :custom_file,
+  #   radio_buttons: :custom_collection,
+  #   range:         :custom_range,
+  #   time:          :custom_multi_select
+  # }
+end

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/lib/templates/erb/scaffold/_form.html.erb
+++ b/lib/templates/erb/scaffold/_form.html.erb
@@ -1,0 +1,15 @@
+<%# frozen_string_literal: true %>
+<%%= simple_form_for(@<%= singular_table_name %>) do |f| %>
+  <%%= f.error_notification %>
+  <%%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
+
+  <div class="form-inputs">
+  <%- attributes.each do |attribute| -%>
+    <%%= f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %> %>
+  <%- end -%>
+  </div>
+
+  <div class="form-actions">
+    <%%= f.button :submit %>
+  </div>
+<%% end %>


### PR DESCRIPTION
## 概要

感情絵文字の一覧が助長だったのでみやすくするためにタブを使って６つに分類しました。
日記作成フォームとユーザー新規登録のフォームを`simple form`にしました。エラーの表示をフォームごとに出したかったため。

## 確認方法

日記新規作成画面、編集画面にいくと確認できます。


## コメント

simple formに関してはログイン画面でも取り入れようと思ったのですがパスの渡し方がわからず断念しました。
感情の絵文字フォームはタブにすることでとてもスッキリしました。

[![Image from Gyazo](https://i.gyazo.com/0cd98d960e8dd3dd01de8c674bdb0e82.gif)](https://gyazo.com/0cd98d960e8dd3dd01de8c674bdb0e82)