### PR TITLE
日記一覧ページ、ユーザー登録、ログインページのレイアウト

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,12 +34,15 @@ class UsersController < ApplicationController
 
   # フォローしている人全員
   def following
-    @users = current_user.followings
+    @user = User.find(params[:user_id])
+    @users = @user.followings
+    @user = User.find(params[:user_id])
   end
 
   # フォロワー全員
   def follower
-    @users = current_user.followers
+    @user = User.find(params[:user_id])
+    @users = @user.followers
   end
 
   # ransackを使って検索したユーザーを@qに入れている

--- a/app/javascript/src/diaries.scss
+++ b/app/javascript/src/diaries.scss
@@ -38,9 +38,9 @@ input[type="radio"]:checked + label img {
 }
 
 /* 日記詳細の枠 */
-.card {
-  margin: 100px;
-  padding: 40px;
+.diary-show {
+  margin-top: 100px;
+  margin-bottom: 100px;
 }
 
 /* サブミットや戻るなどの普通のボタン */
@@ -102,10 +102,9 @@ input[type="radio"]:checked + label img {
   color: #e54747;
 }
 
-/* カレンダー、タイトル含めた全てのクラス */
 .calendar {
-  margin: 100px;
-  padding: 40px;
+  margin-top: 100px;
+  margin-bottom: 100px;
 }
 
 /* カレンダーのタイトル */
@@ -117,6 +116,16 @@ input[type="radio"]:checked + label img {
 /* 友達の日記一覧ページの友達の名前 */
 h3.calendar-name {
   margin-top: 50px;
+}
+
+/* 日記一覧のタイトルになってる名前の編集ページにいくリンク */
+.calendar-name-link {
+  color: #c76e54;
+  letter-spacing: 0.20em;
+}
+
+.calendar-name-link:hover {
+  color: #c76e54;
 }
 
 /* 友達の日記一覧ページの友達の名前のリンク */
@@ -185,4 +194,9 @@ input:checked + .tab_class + .content_class {
 
 .form-group {
   padding-bottom: 2px;
+}
+
+.follow-count {
+  font-size: 12px;
+  color: gray;
 }

--- a/app/javascript/src/header_footer.scss
+++ b/app/javascript/src/header_footer.scss
@@ -17,13 +17,13 @@
 
 /* フッター */
 #footer {
+  position:fixed;
   bottom: 0;
   width: 100%;
-  height: 50px;
+  height: 35px;
   color: gray;
   font-size: 12px;
   background-color: #fbe6de;
-  padding-top: 2px;
 }
 
 /* フッターのリンク */

--- a/app/javascript/src/header_footer.scss
+++ b/app/javascript/src/header_footer.scss
@@ -15,17 +15,8 @@
   letter-spacing: 0.20em;
 }
 
-/* ページ全体の高さ */
-.footerFixed{
-  min-height: 100vh;
-  position: relative;
-  padding-bottom: 60px;
-  box-sizing: border-box;
-}
-
 /* フッター */
-.footer {
-  position: absolute;
+#footer {
   bottom: 0;
   width: 100%;
   height: 50px;
@@ -33,15 +24,6 @@
   font-size: 12px;
   background-color: #fbe6de;
   padding-top: 2px;
-}
-
-body > .container {
-  padding: 60px 15px 0;
-}
-   
-.footer > .container {
-  padding-right: 15px;
-  padding-left: 15px;
 }
 
 /* フッターのリンク */
@@ -55,9 +37,9 @@ body > .container {
 
 /* 日記新規作成のボタン */
 .btn-circle-border {
-  position: absolute;
-  top: 100px;
-  right: 50px;
+  position:fixed;
+  top: 90px;
+  right: 20px;
   margin: 0;
   display: inline-block;
   text-decoration: none;
@@ -73,6 +55,7 @@ body > .container {
   box-shadow: 0px 0px 0px 5px #c76e54;
   border: solid 2px rgba(255, 255, 255, 0.47);
   transition: .4s;
+  z-index: 1;
 }
 
 /* 日記新規作成のボタン、ホバー時 */

--- a/app/javascript/src/home.scss
+++ b/app/javascript/src/home.scss
@@ -22,4 +22,16 @@ body {
   .calendar {
     padding: 40px;
   }
+
+  .resulting {
+    padding: 40px;
+  }
+
+  h3.result {
+    font-size: 35px;
+  }
+
+  tr.edit-form {
+    font-size: 17px;
+  }
 }

--- a/app/javascript/src/home.scss
+++ b/app/javascript/src/home.scss
@@ -10,9 +10,16 @@ body {
 
 /* 画像をレスポンシブ対応させる */
 .img-responsive {
-  display: block;
+  display: flex;
   height: auto;
   max-width: 100%;
   margin-left: auto;
   margin-right: auto;
+}
+
+@media screen and (min-width:600px){
+  /*600px以上で適用する内容*/
+  .calendar {
+    padding: 40px;
+  }
 }

--- a/app/javascript/src/profiles.scss
+++ b/app/javascript/src/profiles.scss
@@ -8,7 +8,7 @@
   border: 1px solid #f5ece4;
   padding: 5px 8px;
   border-radius: 20px;
-  height: 3.0em;
+  height: 2.0em;
   overflow: hidden;
   background: #f5ece4;
   color: gray;
@@ -25,7 +25,7 @@
   border: 1px solid #f5ece4;
   padding: 5px 8px;
   border-radius: 20px;
-  height: 3.0em;
+  height: 2.0em;
   overflow: hidden;
   background: #f5ece4;
   color: gray;
@@ -42,7 +42,7 @@
   border: 1px solid #f5ece4;
   padding: 5px 8px;
   border-radius: 20px;
-  height: 3.0em;
+  height: 2.0em;
   overflow: hidden;
   background: #f5ece4;
   color: gray;
@@ -52,4 +52,9 @@
 .edit-profile input[type="email"]:focus {
   outline: 0;
   background: #f5ece4;
+}
+
+.profile {
+  letter-spacing: 0.20em;
+  color: #c76e54;
 }

--- a/app/javascript/src/profiles.scss
+++ b/app/javascript/src/profiles.scss
@@ -58,3 +58,10 @@
   letter-spacing: 0.20em;
   color: #c76e54;
 }
+
+/* プロフィールのテキスト */
+.edit-form {
+  color: #c76e54;
+  margin-bottom: 30px;
+  font-size: 13px;
+}

--- a/app/javascript/src/users.scss
+++ b/app/javascript/src/users.scss
@@ -59,7 +59,7 @@
 /* フォローボタン */
 .btn.follow-button {
   position: relative;
-  width: 160px;
+  width: 140px;
 	padding: 10px;
   margin: 5px;
 	text-align: center;
@@ -82,7 +82,7 @@
 /* アンフォローボタン */
 .btn.unfollow-button {
   position: relative;
-  width: 160px;
+  width: 140px;
 	padding: 10px;
   margin: 5px;
 	text-align: center;
@@ -112,7 +112,7 @@
   border: 1px solid #f5ece4;
   padding: 5px 8px;
   border-radius: 20px;
-  height: 3.0em;
+  height: 2.0em;
   overflow: hidden;
   background: #f5ece4;
   color: gray;
@@ -129,7 +129,7 @@
   border: 1px solid #f5ece4;
   padding: 5px 8px;
   border-radius: 20px;
-  height: 3.0em;
+  height: 2.0em;
   overflow: hidden;
   background: #f5ece4;
   color: gray;
@@ -147,7 +147,7 @@
   border: 1px solid #f5ece4;
   padding: 5px 8px;
   border-radius: 20px;
-  height: 3.0em;
+  height: 2.0em;
   overflow: hidden;
   background: #f5ece4;
   color: gray;
@@ -172,7 +172,7 @@
   border: 1px solid #f5ece4;
   padding: 5px 8px;
   border-radius: 20px;
-  height: 3.0em;
+  height: 2.0em;
   overflow: hidden;
   background: #f5ece4;
   color: gray;

--- a/app/javascript/src/users.scss
+++ b/app/javascript/src/users.scss
@@ -31,7 +31,7 @@
 .result {
   letter-spacing: 0.20em;
   color: #c76e54;
-  margin-bottom: 80px;
+  margin-bottom: 30px;
 }
 
 /* ユーザー検索結果の友達の名前リンク */
@@ -45,8 +45,8 @@
 
 /* ユーザー検索結果のテーブル、タイトル全てを含めたクラス */
 .resulting {
-  margin: 100px;
-  padding: 40px;
+  margin-top: 100px;
+  margin-bottom: 100px;
 }
 
 /* ユーザー検索結果のテーブル */

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -2,29 +2,42 @@
 
 <div class="container">
 
-  <div class="row calendar justify-content-center">
-    <div class="col-md">
-    <div class="text-right">
-    <% if logged_in? && current_user != @user %>
-      <%= render 'relationships/follow_button_area', user: @user %>
-    <% end %>
-    </div>
-      <h1 class="calendar-name">
-        <%= @user.nickname %> <%= @user.name %>
-      </h1>
-      <%= month_calendar events: @diaries do |date, diaries| %>
-        <%= date.day %>
+  <div class="calendar">
+    <div class="row justify-content-center">
       
-        <% diaries.each do |diary| %>
-          <div class="feeling">
-            <%= link_to diary.feeling, user_diary_path(@user, diary) %>
-          </div>
-        <% end %>
+      <% if logged_in? && current_user != @user %>
+        <h1 class="calendar-name">
+          <%= @user.nickname %><%= @user.name %>
+        </h1>
+        <%= render 'relationships/follow_button_area', user: @user %>
+      <% else %>
+        <h1 class="calendar-name">
+          <%= link_to edit_profiles_path, class: "calendar-name-link" do %>
+            <%= @user.nickname %><%= @user.name %>
+          <% end %>
+        </h1>
       <% end %>
     </div>
-    <div class="chart col-md d-flex align-items-end"> 
-      <%= area_chart @diaries.current_month.group(:start_time).sum(:score) %>
+    
+    <div class="row justify-content-center">
+      <%= render 'relationships/follow_count_area', user: @user %>
     </div>
 
+    <div class="row">
+      <div class="col">
+        <%= month_calendar events: @diaries do |date, diaries| %>
+          <%= date.day %>
+      
+          <% diaries.each do |diary| %>
+            <div class="feeling">
+              <%= link_to diary.feeling, user_diary_path(@user, diary) %>
+            </div>
+          <% end %>
+        <% end %>
+      </div>
+      <div class="chart col d-flex align-items-end"> 
+        <%= area_chart @diaries.current_month.group(:start_time).sum(:score) %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -12,7 +12,7 @@
         <%= render 'relationships/follow_button_area', user: @user %>
       <% else %>
         <h1 class="calendar-name">
-          <%= link_to edit_profiles_path, class: "calendar-name-link" do %>
+          <%= link_to profiles_path, class: "calendar-name-link" do %>
             <%= @user.nickname %><%= @user.name %>
           <% end %>
         </h1>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="row justify-content-center">
-    <div class="card col-10 text-center">
+    <div class="card diary-show col-10 text-center">
       <div class="card-body">
         <div class="card-link text-right">
           <%= render 'bookmarks/bookmark_button', { diary: @diary } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,16 +13,15 @@
   </head>
 
   <body>
-    <div class="footerFixed">
+
       <% if logged_in? %>
         <%= render 'shared/header' %>
-        <%= link_to "write diary", new_user_diary_path(current_user), class: "btn-circle-border" %>
       <% else %>
         <%= render 'shared/before_login_header' %>
       <% end %>
       <%= render 'shared/flash_message' %>
       <%= yield %>
       <%= render 'shared/footer' %>
-    </div>
+
   </body>
 </html>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -2,11 +2,10 @@
 
 <div class="container">
   <div class="row justify-content-center">
-  <div class="resulting col-10">
-      
-  <h1 class="result"><%= current_user.nickname %>edit profile</h1>
+  <div class="card resulting col-10 col-md-6 text-center">
   
-  <div class="row justify-content-center">
+  <div class="card-body text-center">
+    <h3 class="result"><%= current_user.nickname %>edit profile</h3>
     <div class="edit-profile">
           <%= simple_form_for @user, url: profiles_path, local: true do |f| %>
             <div class="form-group">

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -2,12 +2,12 @@
 
 <div class="container">
   <div class="row justify-content-center">
-    <div class="resulting col-10">
+  <div class="resulting col-10">
       
-      <h1 class="result"><%= current_user.nickname %> edit profile</h1>
-      
-      <div class="row justify-content-center">
-        <div class="edit-profile col-6">
+  <h1 class="result"><%= current_user.nickname %>edit profile</h1>
+  
+  <div class="row justify-content-center">
+    <div class="edit-profile">
           <%= simple_form_for @user, url: profiles_path, local: true do |f| %>
             <div class="form-group">
               <%= f.input :name, class: 'form-control mb-3', hint: '半角英数字のみ使用できます' %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,36 +2,35 @@
 
 <div class="container">
   <div class="row justify-content-center">
-  <div class="resulting col-10">
+  <div class="resulting col-10 col-md-5 text-center">
 
   <h2 class="profile text-center"><%= current_user.nickname %> profile</h2>
   
   <div class="row justify-content-center">
-    <div class="">
     <table class="result-table table table-borderless">
 
           <tbody>
-            <tr class="result text-left">
-              <td style="width: 50%">
+            <tr class="edit-form text-left">
+              <td>
                 icon
               </td>
-              <td class="text-right" style="width: 50%">
+              <td class="text-right">
                 <%= current_user.nickname %>
               </td>
             </tr>
-            <tr class="result text-left">
-              <td style="width: 50%">
+            <tr class="edit-form text-left">
+              <td>
                 user name
               </td>
-              <td class="text-right" style="width: 50%">
+              <td class="text-right">
                 <%= current_user.name %>
               </td>
             </tr>
-            <tr class="result text-left">
-              <td style="width: 50%">
+            <tr class="edit-form text-left">
+              <td>
                 email
               </td>
-              <td class="text-right" style="width: 50%">
+              <td class="text-right">
                 <%= current_user.email %>
               </td>
             </tr>
@@ -44,6 +43,5 @@
       <div class="text-center">
         <%= link_to 'edit', edit_profiles_path, class: "btn btn-normal" %>
       </div>
-    </div>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,15 +2,13 @@
 
 <div class="container">
   <div class="row justify-content-center">
-    <div class="resulting col-10">
-      <div class="text-right">
-        <%= link_to 'edit', edit_profiles_path, class: "btn btn-normal" %>
-      </div>
-      <h1 class="result"><%= current_user.nickname %> profile</h1>
-      
-      <div class="row justify-content-center">
-        <div class="col-6">
-        <table class="result-table table table-borderless">
+  <div class="resulting col-10">
+
+  <h2 class="profile text-center"><%= current_user.nickname %> profile</h2>
+  
+  <div class="row justify-content-center">
+    <div class="">
+    <table class="result-table table table-borderless">
 
           <tbody>
             <tr class="result text-left">
@@ -37,26 +35,14 @@
                 <%= current_user.email %>
               </td>
             </tr>
-            <tr class="result text-left">
-              <td style="width: 50%">
-                following counts
-              </td>
-              <td class="text-right" style="width: 50%">
-                <%= link_to current_user.followings.count, following_path, class: "result-link" %>
-              </td>
-            </tr>
-            <tr class="result text-left">
-              <td style="width: 50%">
-                follower counts
-              </td>
-              <td class="text-right" style="width: 50%">
-                <%= link_to current_user.followers.count, follower_path, class: "result-link" %>
-              </td>
-            </tr>
+            
           </tbody>
 
         </table>
-        </div>
+      
+
+      <div class="text-center">
+        <%= link_to 'edit', edit_profiles_path, class: "btn btn-normal" %>
       </div>
     </div>
   </div>

--- a/app/views/relationships/_follow_count_area.html.erb
+++ b/app/views/relationships/_follow_count_area.html.erb
@@ -1,0 +1,9 @@
+<div class="text-center">
+  <%= render 'relationships/following_count', { user: user } %>
+  <p class="follow-count">フォロー中</p>
+</div>
+💛 
+<div class="text-center">
+  <%= render 'relationships/follower_count', { user: user } %>
+  <p class="follow-count">フォロワー</p>
+</div>

--- a/app/views/relationships/_follower_count.html.erb
+++ b/app/views/relationships/_follower_count.html.erb
@@ -1,0 +1,1 @@
+<%= link_to user.followers.count, user_follower_path(user), class: "result-link", id: "followers" %>

--- a/app/views/relationships/_following_count.html.erb
+++ b/app/views/relationships/_following_count.html.erb
@@ -1,0 +1,1 @@
+<%= link_to user.followings.count, user_following_path(user), class: "result-link" %>

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,2 +1,2 @@
 $("#js-follow-button-<%= @other_user.id %>").replaceWith("<%= j(render 'unfollow_button', user: @other_user) %>");
-console.log("Hello");
+$("#followers").html('<%= @other_user.followers.count %>');

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,1 +1,2 @@
 $("#js-follow-button-<%= @user.id %>").replaceWith("<%= j(render 'follow_button', user: @user) %>");
+$("#followers").html('<%= @user.followers.count %>');

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,5 +1,9 @@
-<footer class="footer">
-  <div class="container text-right">
-    <p class="copyright"><p><%= link_to "利用規約", "#", class: "copylight-link" %> | <%= link_to "プライバシーポリシー", "#", class: "copylight-link" %> | © 2021 emory</p></p>
+<footer id='footer'>
+  <div class='container'>
+    <div class='row'>
+      <div class='col-12 text-right'>
+      <p class="copyright"><p><%= link_to "利用規約", "#", class: "copylight-link" %> | <%= link_to "プライバシーポリシー", "#", class: "copylight-link" %> | © 2021 emory</p></p>
+      </div>
+    </div>
   </div>
 </footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header>
+<header >
   <nav class="navbar navbar-expand-lg navigation navbar-light fixed-top" style="background-color: #fbe6de;">
       <%= link_to user_diaries_path(current_user), class: "navbar-brand" do %>
         <img src="<%= asset_pack_path 'media/images/emory.png' %>" >
@@ -21,9 +21,11 @@
           <%= link_to t('defaults.logout'), logout_path, method: :delete, data: { confirm: 'ログアウトしますか？' }, class: 'nav-link' %>
         </li>
         <li class='nav-item'>
-          <%= link_to current_user.nickname, profiles_path %>
+          <%= current_user.nickname %>
         </li>
       </ul>
     </div>
   </nav>
 </header>
+
+<%= link_to "write diary", new_user_diary_path(current_user), class: "btn-circle-border" %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -2,11 +2,11 @@
 
 <div class="container">
   <div class="row justify-content-center">
-    <div class="resulting col-10">
+    <div class="card resulting col-10 col-md-6 text-center">
       
-      <h1 class="result">📖 <%= t '.title' %></h1>
-      <div class="row justify-content-center">
-        <div class="register col-6">
+      <div class="card-body text-center">
+        <h2 class="result card-title">📖 <%= t '.title' %></h2>
+        <div class="register">
         <%= form_with url: login_path, method: :post, local: true do |f| %>
           
             <div class="form-group">

--- a/app/views/users/follower.html.erb
+++ b/app/views/users/follower.html.erb
@@ -4,9 +4,9 @@
   <div class="row justify-content-center">
     <div class="resulting col-10">
       <div class="text-right">
-        <%= link_to 'back', profiles_path, class: "btn btn-normal" %>
+        <%= link_to 'back', user_diaries_path(@user), class: "btn btn-normal" %>
       </div>
-      <h1 class="result"><%= current_user.nickname %> followers</h1>
+      <h1 class="result"><%= @user.nickname %> followers</h1>
       
       <% if @users.empty? %>
         <div class="card">

--- a/app/views/users/following.html.erb
+++ b/app/views/users/following.html.erb
@@ -4,16 +4,23 @@
   <div class="row justify-content-center">
     <div class="resulting col-10">
       <div class="text-right">
-        <%= link_to 'back', profiles_path, class: "btn btn-normal" %>
+        <%= link_to 'back', user_diaries_path(@user), class: "btn btn-normal" %>
       </div>
-      <h1 class="result"><%= current_user.nickname %> followings</h1>
+      <h1 class="result"><%= @user.nickname %> followings</h1>
       
-      <% if @users.empty? %>
+      <% if @users.empty? && current_user == @user %>
+
         <div class="card">
           <div class="card-body text-center">
             <p class="follow_text">まだフォローしている人がいません。<br>
             友達を検索してフォローしませんか？</p>
             <%= link_to 'search friends', users_path, class: 'btn btn-normal' %>
+          </div>
+        </div>
+      <% elsif @users.empty? %>
+        <div class="card">
+          <div class="card-body text-center">
+            <p class="follow_text">まだフォローしている人がいません。
           </div>
         </div>
       <% else %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,12 +2,11 @@
 
 <div class="container">
   <div class="row justify-content-center">
-    <div class="resulting col-10">
+    <div class="card resulting col-10 col-md-6 text-center">
       
-      <h1 class="result">📖 <%= t '.title' %></h1>
-      
-      <div class="row justify-content-center">
-        <div class="register col-6">
+      <div class="card-body text-center">
+        <h2 class="result card-title">📖 <%= t '.title' %></h2>
+        <div class="register">
         <%= simple_form_for @user, local: true do |f| %>
           <div class="form-group">
             <%= f.input :name, class: 'form-control', hint: '半角英数字のみ使用できます' %>
@@ -19,7 +18,7 @@
             <%= f.input :password, class: "form-control", hint: '半角英数字6−12文字を入力してください' %>
           </div>
           <div class="form-group">
-            <%= f.input :password_confirmation, class: "form-control", hint: 'パスワード確認' %>
+            <%= f.input :password_confirmation, class: "form-control" %>
           </div>
 
           <div class="text-center">

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -6,7 +6,7 @@ Chartkick.options = {
   max: 100,
   library: {
     title: {
-      text: 'recent emotional chages',
+      text: '最近の感情の変化',
       align: 'center',
       style: {
         color: '#c76e54'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create, :index, :destroy] do
     resources :followers, only: [:index]
 
+    get 'following', to: 'users#following'
+    get 'follower', to: 'users#follower'
+
     resources :diaries do
       member do
         resources :bookmarks, only: [:index]
@@ -29,7 +32,5 @@ Rails.application.routes.draw do
   # logout_path
   delete 'logout', to: 'user_sessions#destroy', as: :logout
 
-  get 'following', to: 'users#following'
-  get 'follower', to: 'users#follower'
   get 'search', to: 'users#search'
 end


### PR DESCRIPTION
## 概要

c8feb037345700d0448ac461fd507e6c4823440a ユーザー新規登録ページとログインページのレイアウト、並びにフッターのレイアウトをレスポンシブ対応させました。Bootstrapのカードを使ったのでなんか少しダサくなってしまったかもしれないです。
817e59907a06ee3ca5afb5376d4e9f728d8ac20b 日記一覧ページのレイアウトを変更しました。フォロー数のカウントをつけました。また自分のページからは自分の名前を押すとプロフィール編集ページに遷移するようになっています。
557c9742eb2f2c0ff8b780948c4f8c79f3e9dd30 フォロー数のカウントをAjax化しました。フォロワー数だけ必要な機能です。


## コメント

レスポンシブデザインが難しくてつまづきましたが、無駄なpadding、marginを見直すことでうまくいきました。


**_ログインページ_**
[![Image from Gyazo](https://i.gyazo.com/3451bfc96dc67d3ca8f3ebff55bea5b7.png)](https://gyazo.com/3451bfc96dc67d3ca8f3ebff55bea5b7)
[![Image from Gyazo](https://i.gyazo.com/90ebb6e4698a536af176e8bcddaa5adb.png)](https://gyazo.com/90ebb6e4698a536af176e8bcddaa5adb)

**_新規登録ページ_**
[![Image from Gyazo](https://i.gyazo.com/3ce91b449aa65bd2b15ea3d3d7657a07.gif)](https://gyazo.com/3ce91b449aa65bd2b15ea3d3d7657a07)
[![Image from Gyazo](https://i.gyazo.com/073dc6a431c9f0a68487a46e14604d58.gif)](https://gyazo.com/073dc6a431c9f0a68487a46e14604d58)

**_日記一覧ページ_**
[![Image from Gyazo](https://i.gyazo.com/d5b506b42702f1ade0b8ce0a8c4d2fc0.gif)](https://gyazo.com/d5b506b42702f1ade0b8ce0a8c4d2fc0)
[![Image from Gyazo](https://i.gyazo.com/371cebd081fb209e8b0ec73aca7f1989.gif)](https://gyazo.com/371cebd081fb209e8b0ec73aca7f1989)
